### PR TITLE
Enabling HTTP_ACCESS_CONTROL_REQUEST_METHOD

### DIFF
--- a/system/Route.php
+++ b/system/Route.php
@@ -123,7 +123,9 @@ class Route
                 );
 
                 // If matched.
-                $method = count($method) > 0 ? in_array($this->req->method, $method) : true;
+                $method = count($method) > 0 ? (in_array($this->req->method, $method) ||
+                    in_array($this->req->server['REQUEST_METHOD'], $method) ||
+                    in_array($this->req->server['HTTP_ACCESS_CONTROL_REQUEST_METHOD'], $method)): true;
                 if ($method && $this->matched($pattern)) {
                     if ($this->isGroup) {
                         $this->prams = array_merge($this->pramsGroup, $this->prams);


### PR DESCRIPTION
When the request is made by Angular2 HTTP, the method used is always OPTIONS, but with a HTTP_ACCESS_CONTROL_REQUEST_METHOD that "redirects" to the correct method. In this pull request the "match method" will consider the HTTP_ACCESS_CONTROL_REQUEST_METHOD.